### PR TITLE
#[27] feat: 댓글 삭제, 복구 기능 서비스 분리, 댓글 응답 유저이름 nickname -> username으로 변경

### DIFF
--- a/src/main/java/com/b3/ddarelro/domain/comment/dto/response/CommentListRes.java
+++ b/src/main/java/com/b3/ddarelro/domain/comment/dto/response/CommentListRes.java
@@ -3,6 +3,6 @@ package com.b3.ddarelro.domain.comment.dto.response;
 import lombok.Builder;
 
 @Builder
-public record CommentListRes(Long id, String content, String nickname) {
+public record CommentListRes(Long id, String content, String username) {
 
 }

--- a/src/main/java/com/b3/ddarelro/domain/comment/service/CommentDeleteRestoreService.java
+++ b/src/main/java/com/b3/ddarelro/domain/comment/service/CommentDeleteRestoreService.java
@@ -1,0 +1,30 @@
+package com.b3.ddarelro.domain.comment.service;
+
+import com.b3.ddarelro.domain.comment.repository.CommentRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentDeleteRestoreService {
+
+    private final CommentRepository commentRepository;
+
+    /**
+     * Card가 delete할 때, 이 메소드를 호출 (상위에서 soft delete한 경우에만 카드도 soft delete를 실행)
+     */
+    public void deleteAllComment(List<Long> cardIds) {
+        commentRepository.SoftDelete(cardIds);
+    }
+
+    /**
+     * Card가 restore할 때 comment도 restore 한다.
+     */
+    public void restoreAllComment(List<Long> cardIds) {
+        commentRepository.restoreAll(cardIds);
+    }
+
+}

--- a/src/main/java/com/b3/ddarelro/domain/comment/service/CommentService.java
+++ b/src/main/java/com/b3/ddarelro/domain/comment/service/CommentService.java
@@ -68,23 +68,9 @@ public class CommentService {
             .map(comment -> CommentListRes.builder()
                 .id(comment.getId())
                 .content(comment.getContent())
-                .nickname(comment.getUser().getUsername())
+                .username(comment.getUser().getUsername())
                 .build())
             .toList();
-    }
-
-    /**
-     * Card가 delete할 때, 이 메소드를 호출 (상위에서 soft delete한 경우에만 카드도 soft delete를 실행)
-     */
-    public void deleteAllComment(List<Long> cardIds) {
-        commentRepository.SoftDelete(cardIds);
-    }
-
-    /**
-     * Card가 restore할 때 comment도 restore 한다.
-     */
-    public void restoreAllComment(List<Long> cardIds) {
-        commentRepository.restoreAll(cardIds);
     }
 
     private Comment findComment(Long commentId) {


### PR DESCRIPTION
## 개요
댓글의 삭제, 복구 기능 서비스 분리 및 응답 데이터 이름 변경

## 작업사항
- CommentDeleteRestoreService 생성
- 위 생성한 서비스 안에 삭제, 복구 기능 구현

## 변경로직
- 기존 CommentService에서 담당하던 SoftDelete 관련된 로직을 CommentDeleteRestoreService로 분리하여 처리

## 관련 이슈
- #27 
