### PR TITLE
컬럼 soft delete, restore 기능 구현

### DIFF
--- a/src/main/java/com/b3/ddarelro/domain/column/controller/ColumnController.java
+++ b/src/main/java/com/b3/ddarelro/domain/column/controller/ColumnController.java
@@ -3,9 +3,11 @@ package com.b3.ddarelro.domain.column.controller;
 import com.b3.ddarelro.domain.column.dto.request.ColumnCreateReq;
 import com.b3.ddarelro.domain.column.dto.request.ColumnDeleteReq;
 import com.b3.ddarelro.domain.column.dto.request.ColumnGetReq;
+import com.b3.ddarelro.domain.column.dto.request.ColumnRestoreReq;
 import com.b3.ddarelro.domain.column.dto.request.ColumnUpdateReq;
 import com.b3.ddarelro.domain.column.dto.response.ColumnCreateRes;
 import com.b3.ddarelro.domain.column.dto.response.ColumnDeleteRes;
+import com.b3.ddarelro.domain.column.dto.response.ColumnRestoreRes;
 import com.b3.ddarelro.domain.column.dto.response.ColumnUpdateRes;
 import com.b3.ddarelro.domain.column.dto.response.ColumnsGetRes;
 import com.b3.ddarelro.domain.column.service.ColumnService;
@@ -18,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -60,6 +63,15 @@ public class ColumnController {
         @Valid @RequestBody ColumnDeleteReq req,
         @AuthenticationPrincipal UserDetailsImpl userDetails) {
         ColumnDeleteRes res = columnService.deleteColumn(columnId, req,
+            userDetails.getUser().getId());
+        return ResponseEntity.status(HttpStatus.OK).body(res);
+    }
+
+    @PatchMapping("/{columnId}/restore")
+    public ResponseEntity<ColumnRestoreRes> restoreColumn(@PathVariable Long columnId,
+        @Valid @RequestBody ColumnRestoreReq req,
+        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        ColumnRestoreRes res = columnService.restoreColumn(columnId, req,
             userDetails.getUser().getId());
         return ResponseEntity.status(HttpStatus.OK).body(res);
     }

--- a/src/main/java/com/b3/ddarelro/domain/column/dto/request/ColumnRestoreReq.java
+++ b/src/main/java/com/b3/ddarelro/domain/column/dto/request/ColumnRestoreReq.java
@@ -1,0 +1,5 @@
+package com.b3.ddarelro.domain.column.dto.request;
+
+public record ColumnRestoreReq(Long boardId) {
+
+}

--- a/src/main/java/com/b3/ddarelro/domain/column/dto/response/ColumnRestoreRes.java
+++ b/src/main/java/com/b3/ddarelro/domain/column/dto/response/ColumnRestoreRes.java
@@ -1,0 +1,8 @@
+package com.b3.ddarelro.domain.column.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record ColumnRestoreRes(String title, Boolean deleted) {
+
+}

--- a/src/main/java/com/b3/ddarelro/domain/column/entity/Column.java
+++ b/src/main/java/com/b3/ddarelro/domain/column/entity/Column.java
@@ -50,4 +50,8 @@ public class Column extends BaseEntity {
     public void delete() {
         this.deleted = true;
     }
+
+    public void restore() {
+        this.deleted = false;
+    }
 }

--- a/src/main/java/com/b3/ddarelro/domain/column/repository/ColumnRepository.java
+++ b/src/main/java/com/b3/ddarelro/domain/column/repository/ColumnRepository.java
@@ -11,7 +11,7 @@ public interface ColumnRepository extends JpaRepository<Column, Long> {
         + "join fetch c.board b "
         + "where b.id = :boardId and c.deleted = false "
         + "order by c.priority")
-    List<Column> findAllByBoardId(Long boardId);
+    List<Column> findAllByBoardIdAndNotDeleted(Long boardId);
 
     @Query("select count(*) from Column c "
         + "join c.board b "

--- a/src/main/java/com/b3/ddarelro/domain/column/repository/ColumnRepository.java
+++ b/src/main/java/com/b3/ddarelro/domain/column/repository/ColumnRepository.java
@@ -13,6 +13,11 @@ public interface ColumnRepository extends JpaRepository<Column, Long> {
         + "order by c.priority")
     List<Column> findAllByBoardIdAndNotDeleted(Long boardId);
 
+    @Query("select c.id from Column c "
+        + "join fetch c.board b "
+        + "where b.id = :boardId and c.deleted = true ")
+    List<Long> findAllByBoardIdAndDeleted(Long boardId);
+
     @Query("select count(*) from Column c "
         + "join c.board b "
         + "where b.id = :boardId")
@@ -22,4 +27,9 @@ public interface ColumnRepository extends JpaRepository<Column, Long> {
         + "set c.deleted=true "
         + "where c.id in (:columnIdList)")
     void softDelete(List<Long> columnIdList);
+
+    @Query("update Column c "
+        + "set c.deleted=false "
+        + "where c.id in (:columnIdList)")
+    void softRestore(List<Long> columnIdList);
 }

--- a/src/main/java/com/b3/ddarelro/domain/column/service/ColumnDeleteRestoreService.java
+++ b/src/main/java/com/b3/ddarelro/domain/column/service/ColumnDeleteRestoreService.java
@@ -11,12 +11,12 @@ import org.springframework.stereotype.Service;
 public class ColumnDeleteRestoreService {
 
     private final ColumnRepository columnRepository;
-    private final CardDeleteRestoreService cardDeleteRestoreService;
+//    private final CardDeleteRestoreService cardDeleteRestoreService;
 
     public void deleteAllColumn(Long boardId) {
         List<Column> columns = columnRepository.findAllByBoardId(boardId);
         List<Long> columnIdList = columns.stream().map(Column::getId).toList();
         columns.forEach(Column::delete);
-        cardDeleteRestoreService.deleteAllCard(columnIdList);
+//        cardDeleteRestoreService.deleteAllCard(columnIdList);
     }
 }

--- a/src/main/java/com/b3/ddarelro/domain/column/service/ColumnDeleteRestoreService.java
+++ b/src/main/java/com/b3/ddarelro/domain/column/service/ColumnDeleteRestoreService.java
@@ -19,4 +19,10 @@ public class ColumnDeleteRestoreService {
         columnRepository.softDelete(columnIdList);
 //        cardDeleteRestoreService.deleteAllCard(columnIdList);
     }
+
+    public void restoreAllColumn(Long boardId) {
+        List<Long> columnIdList = columnRepository.findAllByBoardIdAndDeleted(boardId);
+        columnRepository.softRestore(columnIdList);
+//        cardDeleteRestoreService.restoreAllCard(columnIdList);
+    }
 }

--- a/src/main/java/com/b3/ddarelro/domain/column/service/ColumnDeleteRestoreService.java
+++ b/src/main/java/com/b3/ddarelro/domain/column/service/ColumnDeleteRestoreService.java
@@ -16,7 +16,7 @@ public class ColumnDeleteRestoreService {
     public void deleteAllColumn(Long boardId) {
         List<Column> columns = columnRepository.findAllByBoardId(boardId);
         List<Long> columnIdList = columns.stream().map(Column::getId).toList();
-        columns.forEach(Column::delete);
+        columnRepository.softDelete(columnIdList);
 //        cardDeleteRestoreService.deleteAllCard(columnIdList);
     }
 }

--- a/src/main/java/com/b3/ddarelro/domain/column/service/ColumnDeleteRestoreService.java
+++ b/src/main/java/com/b3/ddarelro/domain/column/service/ColumnDeleteRestoreService.java
@@ -1,0 +1,22 @@
+package com.b3.ddarelro.domain.column.service;
+
+import com.b3.ddarelro.domain.column.entity.Column;
+import com.b3.ddarelro.domain.column.repository.ColumnRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ColumnDeleteRestoreService {
+
+    private final ColumnRepository columnRepository;
+    private final CardDeleteRestoreService cardDeleteRestoreService;
+
+    public void deleteAllColumn(Long boardId) {
+        List<Column> columns = columnRepository.findAllByBoardId(boardId);
+        List<Long> columnIdList = columns.stream().map(Column::getId).toList();
+        columns.forEach(Column::delete);
+        cardDeleteRestoreService.deleteAllCard(columnIdList);
+    }
+}

--- a/src/main/java/com/b3/ddarelro/domain/column/service/ColumnDeleteRestoreService.java
+++ b/src/main/java/com/b3/ddarelro/domain/column/service/ColumnDeleteRestoreService.java
@@ -14,7 +14,7 @@ public class ColumnDeleteRestoreService {
 //    private final CardDeleteRestoreService cardDeleteRestoreService;
 
     public void deleteAllColumn(Long boardId) {
-        List<Column> columns = columnRepository.findAllByBoardId(boardId);
+        List<Column> columns = columnRepository.findAllByBoardIdAndNotDeleted(boardId);
         List<Long> columnIdList = columns.stream().map(Column::getId).toList();
         columnRepository.softDelete(columnIdList);
 //        cardDeleteRestoreService.deleteAllCard(columnIdList);

--- a/src/main/java/com/b3/ddarelro/domain/column/service/ColumnService.java
+++ b/src/main/java/com/b3/ddarelro/domain/column/service/ColumnService.java
@@ -55,7 +55,7 @@ public class ColumnService {
 
         boardService.validateMember(user, board);
 
-        List<Column> columns = columnRepository.findAllByBoardId(board.getId());
+        List<Column> columns = columnRepository.findAllByBoardIdAndNotDeleted(board.getId());
 
         return columns.stream().map(column -> ColumnsGetRes.builder()
             .title(column.getTitle()).build()).toList();

--- a/src/main/java/com/b3/ddarelro/domain/column/service/ColumnService.java
+++ b/src/main/java/com/b3/ddarelro/domain/column/service/ColumnService.java
@@ -28,7 +28,7 @@ public class ColumnService {
     private final ColumnRepository columnRepository;
     private final BoardService boardService;
     private final UserService userService;
-    //private final CardService cardService;
+    private final CardDeleteRestoreService cardDeleteRestoreService;
 
     public ColumnCreateRes createColumn(ColumnCreateReq req, Long userId) {
         Board board = getBoardAndLeaderCheck(req.boardId(), userId);
@@ -77,19 +77,12 @@ public class ColumnService {
 
         Column column = findColumn(columnId);
         column.delete();
-        //cardService.deleteAllCard(List.of(columnId));
+        cardDeleteRestoreService.deleteAllCard(List.of(columnId));
 
         return ColumnDeleteRes.builder()
             .title(column.getTitle())
             .deleted(column.getDeleted())
             .build();
-    }
-
-    public void deleteAllColumn(Long boardId) {
-        List<Column> columns = columnRepository.findAllByBoardId(boardId);
-        List<Long> columnIdList = columns.stream().map(Column::getId).toList();
-        columns.forEach(Column::delete);
-        //cardService.deleteAllCard(columnIdList);
     }
 
     public Column findColumn(Long columnId) {

--- a/src/main/java/com/b3/ddarelro/domain/column/service/ColumnService.java
+++ b/src/main/java/com/b3/ddarelro/domain/column/service/ColumnService.java
@@ -5,9 +5,11 @@ import com.b3.ddarelro.domain.board.service.BoardService;
 import com.b3.ddarelro.domain.column.dto.request.ColumnCreateReq;
 import com.b3.ddarelro.domain.column.dto.request.ColumnDeleteReq;
 import com.b3.ddarelro.domain.column.dto.request.ColumnGetReq;
+import com.b3.ddarelro.domain.column.dto.request.ColumnRestoreReq;
 import com.b3.ddarelro.domain.column.dto.request.ColumnUpdateReq;
 import com.b3.ddarelro.domain.column.dto.response.ColumnCreateRes;
 import com.b3.ddarelro.domain.column.dto.response.ColumnDeleteRes;
+import com.b3.ddarelro.domain.column.dto.response.ColumnRestoreRes;
 import com.b3.ddarelro.domain.column.dto.response.ColumnUpdateRes;
 import com.b3.ddarelro.domain.column.dto.response.ColumnsGetRes;
 import com.b3.ddarelro.domain.column.entity.Column;
@@ -28,7 +30,7 @@ public class ColumnService {
     private final ColumnRepository columnRepository;
     private final BoardService boardService;
     private final UserService userService;
-    private final CardDeleteRestoreService cardDeleteRestoreService;
+//    private final CardDeleteRestoreService cardDeleteRestoreService;
 
     public ColumnCreateRes createColumn(ColumnCreateReq req, Long userId) {
         Board board = getBoardAndLeaderCheck(req.boardId(), userId);
@@ -77,9 +79,23 @@ public class ColumnService {
 
         Column column = findColumn(columnId);
         column.delete();
-        cardDeleteRestoreService.deleteAllCard(List.of(columnId));
+//        cardDeleteRestoreService.deleteAllCard(List.of(columnId));
 
         return ColumnDeleteRes.builder()
+            .title(column.getTitle())
+            .deleted(column.getDeleted())
+            .build();
+    }
+
+    @Transactional
+    public ColumnRestoreRes restoreColumn(Long columnId, ColumnRestoreReq req, Long userId) {
+        getBoardAndLeaderCheck(req.boardId(), userId);
+
+        Column column = findColumn(columnId);
+        column.restore();
+//        cardDeleteRestoreService.restoreAllCard(List.of(columnId));
+
+        return ColumnRestoreRes.builder()
             .title(column.getTitle())
             .deleted(column.getDeleted())
             .build();


### PR DESCRIPTION
## 개요
컬럼 soft delete, restore 기능 구현

## 작업사항
- soft delete된 column을 복구할 때 카드도 복구 되는 api 구현
- soft delete된 board가 복구하면서 column도 같이 복구할 수 있게 하는 기능 구현

## 변경로직
- 서비스에서 변경감지 이용해서 업데이트-> JPQL  이용해서 업데이트 (deleteAll())

## 관련 이슈
-  close #18 
