### PR TITLE
[#5] Feat/card delete

### DIFF
--- a/src/main/java/com/b3/ddarelro/domain/card/controller/CardController.java
+++ b/src/main/java/com/b3/ddarelro/domain/card/controller/CardController.java
@@ -1,27 +1,14 @@
 package com.b3.ddarelro.domain.card.controller;
 
-import com.b3.ddarelro.domain.card.dto.request.CardCreateReq;
-import com.b3.ddarelro.domain.card.dto.request.CardDeleteReq;
-import com.b3.ddarelro.domain.card.dto.request.CardDueDateReq;
-import com.b3.ddarelro.domain.card.dto.request.CardModifyReq;
-import com.b3.ddarelro.domain.card.dto.response.CardCreateRes;
-import com.b3.ddarelro.domain.card.dto.response.CardDeleteRes;
-import com.b3.ddarelro.domain.card.dto.response.CardDueDateRes;
-import com.b3.ddarelro.domain.card.dto.response.CardListRes;
-import com.b3.ddarelro.domain.card.dto.response.CardModifyRes;
-import com.b3.ddarelro.domain.card.dto.response.CardRes;
-import com.b3.ddarelro.domain.card.service.CardService;
-import java.util.List;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.b3.ddarelro.domain.card.dto.request.*;
+import com.b3.ddarelro.domain.card.dto.response.*;
+import com.b3.ddarelro.domain.card.service.*;
+import com.b3.ddarelro.global.security.*;
+import java.util.*;
+import lombok.*;
+import org.springframework.http.*;
+import org.springframework.security.core.annotation.*;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,21 +18,25 @@ public class CardController {
     private final CardService cardService;
 
     @PostMapping
-    public ResponseEntity<CardCreateRes> createCard(@RequestBody CardCreateReq req) {
+    public ResponseEntity<CardCreateRes> createCard(@RequestBody CardCreateReq req,
+        @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-        CardCreateRes res = cardService.createCard(req);
+        CardCreateRes res = cardService.createCard(req, userDetails.getUser());
         return ResponseEntity.status(201).body(res);
     }
 
     @GetMapping
-    public ResponseEntity<List<CardListRes>> getCardList() {
-        List<CardListRes> resList = cardService.getCardList();
+    public ResponseEntity<List<CardListRes>> getCardList(@RequestBody CardListReq req,
+        @AuthenticationPrincipal
+        UserDetailsImpl userDetails) {
+        List<CardListRes> resList = cardService.getCardList(req, userDetails.getUser());
         return ResponseEntity.ok().body(resList);
     }
 
     @GetMapping("/{cardId}")
-    public ResponseEntity<CardRes> getCard(@PathVariable Long cardId) {
-        CardRes res = cardService.getCard(cardId);
+    public ResponseEntity<CardRes> getCard(@PathVariable Long cardId, @RequestBody CardReq req,
+        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        CardRes res = cardService.getCard(cardId, req, userDetails.getUser());
         return ResponseEntity.ok().body(res);
     }
 
@@ -59,23 +50,23 @@ public class CardController {
 
     @PatchMapping("/{cardId}")
     public ResponseEntity<CardModifyRes> modifyCard(@PathVariable Long cardId,
-        @RequestBody CardModifyReq req) {
-        CardModifyRes res = cardService.modifyCard(cardId, req);
+        @RequestBody CardModifyReq req, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        CardModifyRes res = cardService.modifyCard(cardId, req, userDetails.getUser());
         return ResponseEntity.ok().body(res);
     }
 
-    //TODO 마감일 설정
     @PatchMapping("/{cardId}/dueDate")
     public ResponseEntity<CardDueDateRes> setDueDateCard(@PathVariable Long cardId,
-        @RequestBody CardDueDateReq req) {
-        CardDueDateRes res = cardService.setDueDateCard(cardId, req);
+        @RequestBody CardDueDateReq req, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        CardDueDateRes res = cardService.setDueDateCard(cardId, req, userDetails.getUser());
         return ResponseEntity.ok().body(res);
     }
 
     @DeleteMapping("/{cardId}")
     public ResponseEntity<CardDeleteRes> deleteCard(@PathVariable Long cardId,
-        @RequestBody CardDeleteReq req) {
-        CardDeleteRes resDto = cardService.deleteCard(cardId, req);
+        @RequestBody CardDeleteReq req, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        CardDeleteRes resDto = cardService.deleteCard(cardId, req,
+            userDetails.getUser());
         return ResponseEntity.ok().body(resDto);
     }
 

--- a/src/main/java/com/b3/ddarelro/domain/card/dto/request/CardListReq.java
+++ b/src/main/java/com/b3/ddarelro/domain/card/dto/request/CardListReq.java
@@ -1,0 +1,5 @@
+package com.b3.ddarelro.domain.card.dto.request;
+
+public record CardListReq(Long columnId) {
+
+}

--- a/src/main/java/com/b3/ddarelro/domain/card/dto/request/CardReq.java
+++ b/src/main/java/com/b3/ddarelro/domain/card/dto/request/CardReq.java
@@ -1,0 +1,5 @@
+package com.b3.ddarelro.domain.card.dto.request;
+
+public record CardReq(Long columnId) {
+
+}

--- a/src/main/java/com/b3/ddarelro/domain/card/dto/response/CardCreateRes.java
+++ b/src/main/java/com/b3/ddarelro/domain/card/dto/response/CardCreateRes.java
@@ -1,30 +1,32 @@
 package com.b3.ddarelro.domain.card.dto.response;
 
-import com.b3.ddarelro.domain.card.entity.Card;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import lombok.Builder;
+import com.b3.ddarelro.domain.card.entity.*;
+import java.time.*;
+import lombok.*;
 
 @Builder
 public record CardCreateRes(
     String name,
+    String username,
     String description,
     String color,
     LocalDate dueDate,
     LocalDateTime createdAt,
-    LocalDateTime modifiedAt
+    LocalDateTime modifiedAt,
+    Long priority
 
 ) {
 
-    public static CardCreateRes formingWith(Card card) {
+    public static CardCreateRes formingWith(Card card, Long priority) {
         return CardCreateRes.builder()
             .name(card.getName())
-            //.username
+            .username(card.getUser().getUsername())
             .description(card.getDescription())
             .color(card.getColor())
             .dueDate(card.getDueDate())
             .createdAt(card.getCreatedAt())
             .modifiedAt(card.getModifiedAt())
+            .priority(priority)
             .build();
     }
 

--- a/src/main/java/com/b3/ddarelro/domain/card/dto/response/CardDueDateRes.java
+++ b/src/main/java/com/b3/ddarelro/domain/card/dto/response/CardDueDateRes.java
@@ -1,30 +1,32 @@
 package com.b3.ddarelro.domain.card.dto.response;
 
-import com.b3.ddarelro.domain.card.entity.Card;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import lombok.Builder;
+import com.b3.ddarelro.domain.card.entity.*;
+import java.time.*;
+import lombok.*;
 
 @Builder
 public record CardDueDateRes(
     String name,
+    String username,
     String description,
     String color,
     LocalDate dueDate,
     LocalDateTime createdAt,
-    LocalDateTime modifiedAt
+    LocalDateTime modifiedAt,
+    Long priority
 
 ) {
 
     public static CardDueDateRes formWith(Card card, LocalDate dueDate) {
         return CardDueDateRes.builder()
             .name(card.getName())
-            //.username
+            .username(card.getUser().getUsername())
             .description(card.getDescription())
             .color(card.getColor())
             .dueDate(dueDate)
             .createdAt(card.getCreatedAt())
             .modifiedAt(card.getModifiedAt())
+            .priority(card.getPriority())
             .build();
     }
 }

--- a/src/main/java/com/b3/ddarelro/domain/card/dto/response/CardListRes.java
+++ b/src/main/java/com/b3/ddarelro/domain/card/dto/response/CardListRes.java
@@ -1,11 +1,12 @@
 package com.b3.ddarelro.domain.card.dto.response;
 
-import com.b3.ddarelro.domain.card.entity.Card;
-import java.time.LocalDateTime;
-import lombok.Builder;
+import com.b3.ddarelro.domain.card.entity.*;
+import java.time.*;
+import lombok.*;
 
 @Builder
 public record CardListRes(
+    Long id,
     String name,
     String description,
     String color,
@@ -15,6 +16,7 @@ public record CardListRes(
 
     public static CardListRes formWith(Card card) {
         return CardListRes.builder()
+            .id(card.getId())
             .name(card.getName())
             //.username(card.getUser().getUsername())
             .description(card.getDescription())

--- a/src/main/java/com/b3/ddarelro/domain/card/dto/response/CardModifyRes.java
+++ b/src/main/java/com/b3/ddarelro/domain/card/dto/response/CardModifyRes.java
@@ -1,30 +1,32 @@
 package com.b3.ddarelro.domain.card.dto.response;
 
-import com.b3.ddarelro.domain.card.entity.Card;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import lombok.Builder;
+import com.b3.ddarelro.domain.card.entity.*;
+import java.time.*;
+import lombok.*;
 
 @Builder
 public record CardModifyRes(
     String name,
+    String username,
     String description,
     String color,
     LocalDate dueDate,
     LocalDateTime createdAt,
-    LocalDateTime modifiedAt
+    LocalDateTime modifiedAt,
+    Long priority
 
 ) {
 
     public static CardModifyRes formWith(Card card) {
         return CardModifyRes.builder()
             .name(card.getName())
-            //.username
+            .username(card.getUser().getUsername())
             .description(card.getDescription())
             .color(card.getColor())
             .dueDate(card.getDueDate())
             .createdAt(card.getCreatedAt())
             .modifiedAt(card.getModifiedAt())
+            .priority(card.getPriority())
             .build();
     }
 }

--- a/src/main/java/com/b3/ddarelro/domain/card/dto/response/CardRes.java
+++ b/src/main/java/com/b3/ddarelro/domain/card/dto/response/CardRes.java
@@ -1,30 +1,33 @@
 package com.b3.ddarelro.domain.card.dto.response;
 
-import com.b3.ddarelro.domain.card.entity.Card;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import lombok.Builder;
+import com.b3.ddarelro.domain.card.entity.*;
+import java.time.*;
+import lombok.*;
 
 @Builder
 public record CardRes(
+    Long id,
     String name,
+    String username,
     String description,
     String color,
     LocalDate dueDate,
     LocalDateTime createdAt,
-    LocalDateTime modifiedAt
+    LocalDateTime modifiedAt,
+    Long priority
 
 ) {
 
     public static CardRes formWith(Card card) {
         return CardRes.builder()
             .name(card.getName())
-//            .username(card.getUser().getUsername())
+            .username(card.getUser().getUsername())
             .description(card.getDescription())
             .color(card.getColor())
             .dueDate(card.getDueDate())
             .createdAt(card.getCreatedAt())
             .modifiedAt(card.getModifiedAt())
+            .priority(card.getPriority())
             .build();
     }
 }

--- a/src/main/java/com/b3/ddarelro/domain/card/entity/Card.java
+++ b/src/main/java/com/b3/ddarelro/domain/card/entity/Card.java
@@ -1,26 +1,13 @@
 package com.b3.ddarelro.domain.card.entity;
 
-import com.b3.ddarelro.domain.card.dto.request.CardModifyReq;
-import com.b3.ddarelro.domain.comment.entity.Comment;
-import com.b3.ddarelro.domain.common.BaseEntity;
-import com.b3.ddarelro.domain.user.entity.User;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import java.time.LocalDate;
-import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.b3.ddarelro.domain.card.dto.request.*;
+import com.b3.ddarelro.domain.comment.entity.*;
+import com.b3.ddarelro.domain.common.*;
+import com.b3.ddarelro.domain.user.entity.*;
+import jakarta.persistence.*;
+import java.time.*;
+import java.util.*;
+import lombok.*;
 
 @Entity
 @Getter
@@ -40,20 +27,25 @@ public class Card extends BaseEntity {
     private String color;
     private LocalDate dueDate;
     private Boolean deleted;
+    private Long priority;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
-    @OneToMany(mappedBy = "card", cascade = CascadeType.ALL, orphanRemoval = true)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private com.b3.ddarelro.domain.column.entity.Column column;
+    @OneToMany(mappedBy = "card")
     private List<Comment> commentList;
 
     @Builder
-    public Card(String name, String description, String color, Boolean deleted, User user,
+    public Card(String name, String description, String color, Boolean deleted, Long priority,
+        User user,
         List<Comment> commentList) {
         this.name = name;
         this.description = description;
         this.color = color;
         this.deleted = deleted;
+        this.priority = priority;
         this.user = user;
         this.commentList = commentList;
     }

--- a/src/main/java/com/b3/ddarelro/domain/card/repository/CardRepository.java
+++ b/src/main/java/com/b3/ddarelro/domain/card/repository/CardRepository.java
@@ -1,10 +1,27 @@
 package com.b3.ddarelro.domain.card.repository;
 
-import com.b3.ddarelro.domain.card.entity.Card;
-import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
+import com.b3.ddarelro.domain.card.entity.*;
+import com.b3.ddarelro.domain.column.entity.*;
+import java.util.*;
+import org.springframework.data.jpa.repository.*;
 
 public interface CardRepository extends JpaRepository<Card, Long> {
 
     List<Card> findAllByOrderByCreatedAtDesc();
+
+    @Query("select count(*) from Card c where c.column.id = :columnId")
+    Long countByColumnId(Long columnId);
+
+    @Query(
+        "select c from Card c join fetch c.column cl where cl.id = :columnId and c.deleted = false "
+            + "order by c.priority")
+    List<Column> findAllByColumnId(Long columnId);
+
+    @Modifying
+    @Query(value = "update Card c set c.deleted = true where c.column.id in (:columnIds)")
+    void SoftDelete(List<Long> columnIds);
+
+    @Modifying
+    @Query(value = "update Card c set c.deleted = false where c.column.id in (:columnIds)")
+    void restoreAll(List<Long> columnIds);
 }

--- a/src/main/java/com/b3/ddarelro/domain/card/service/CardDeleteRestoreService.java
+++ b/src/main/java/com/b3/ddarelro/domain/card/service/CardDeleteRestoreService.java
@@ -1,0 +1,24 @@
+package com.b3.ddarelro.domain.card.service;
+
+import com.b3.ddarelro.domain.card.repository.*;
+import java.util.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CardDeleteRestoreService {
+
+    private final CardRepository cardRepository;
+
+
+    public void deleteAllCard(List<Long> columnIds) {
+        cardRepository.SoftDelete(columnIds);
+    }
+
+    public void restoreAllComment(List<Long> columnIds) {
+        cardRepository.restoreAll(columnIds);
+    }
+}


### PR DESCRIPTION
## 개요
카드 삭제 구현 / 기타 엔티티 및 메서드 정리 / 'DeleteRestore' 서비스 추가

## 작업사항
- 카드 삭제시 `deleteAllComment()` 호출
- Column삭제/복구시 호출할 deleteAllCard, restoreAllComment 구현

## 변경로직
- Card Entity 에 priority 필드값 추가

## 관련 이슈
- 
