### PR TITLE
Feat/check list 체크리스트 API 구현

### DIFF
--- a/src/main/java/com/b3/ddarelro/domain/checklist/controller/CheckListController.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/controller/CheckListController.java
@@ -4,10 +4,12 @@ import static org.springframework.http.HttpStatus.CREATED;
 
 import com.b3.ddarelro.domain.checklist.dto.request.CheckListCreateReq;
 import com.b3.ddarelro.domain.checklist.dto.response.CheckListCreateRes;
+import com.b3.ddarelro.domain.checklist.dto.response.CheckListGetListRes;
 import com.b3.ddarelro.domain.checklist.service.CheckListService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,5 +29,11 @@ public class CheckListController {
 
         CheckListCreateRes res = checkListService.createCheckList(cardId, req);
         return ResponseEntity.status(CREATED).body(res);
+    }
+
+    @GetMapping("/{cardId}/checkList")
+    public ResponseEntity<CheckListGetListRes> getCheckList(@PathVariable Long cardId) {
+        CheckListGetListRes res = checkListService.getCheckList(cardId);
+        return ResponseEntity.ok(res);
     }
 }

--- a/src/main/java/com/b3/ddarelro/domain/checklist/controller/CheckListController.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/controller/CheckListController.java
@@ -1,0 +1,31 @@
+package com.b3.ddarelro.domain.checklist.controller;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+import com.b3.ddarelro.domain.checklist.dto.request.CheckListCreateReq;
+import com.b3.ddarelro.domain.checklist.dto.response.CheckListCreateRes;
+import com.b3.ddarelro.domain.checklist.service.CheckListService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/cards")
+@RequiredArgsConstructor
+public class CheckListController {
+
+    private final CheckListService checkListService;
+
+    @PostMapping("/{cardId}/checkList")
+    public ResponseEntity<CheckListCreateRes> createCheckList(@PathVariable Long cardId,
+        @RequestBody @Valid CheckListCreateReq req) {
+
+        CheckListCreateRes res = checkListService.createCheckList(cardId, req);
+        return ResponseEntity.status(CREATED).body(res);
+    }
+}

--- a/src/main/java/com/b3/ddarelro/domain/checklist/controller/CheckListController.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/controller/CheckListController.java
@@ -3,6 +3,7 @@ package com.b3.ddarelro.domain.checklist.controller;
 import static org.springframework.http.HttpStatus.CREATED;
 
 import com.b3.ddarelro.domain.checklist.dto.request.CheckListCreateReq;
+import com.b3.ddarelro.domain.checklist.dto.response.CheckListCompletedRes;
 import com.b3.ddarelro.domain.checklist.dto.response.CheckListCreateRes;
 import com.b3.ddarelro.domain.checklist.dto.response.CheckListGetListRes;
 import com.b3.ddarelro.domain.checklist.service.CheckListService;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,6 +36,14 @@ public class CheckListController {
     @GetMapping("/{cardId}/checkList")
     public ResponseEntity<CheckListGetListRes> getCheckList(@PathVariable Long cardId) {
         CheckListGetListRes res = checkListService.getCheckList(cardId);
+        return ResponseEntity.ok(res);
+    }
+
+    @PutMapping("/checkList/{checkListId}")
+    public ResponseEntity<CheckListCompletedRes> completedCheckList(
+        @PathVariable Long checkListId) {
+
+        CheckListCompletedRes res = checkListService.completedCheckList(checkListId);
         return ResponseEntity.ok(res);
     }
 }

--- a/src/main/java/com/b3/ddarelro/domain/checklist/controller/CheckListController.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/controller/CheckListController.java
@@ -5,11 +5,13 @@ import static org.springframework.http.HttpStatus.CREATED;
 import com.b3.ddarelro.domain.checklist.dto.request.CheckListCreateReq;
 import com.b3.ddarelro.domain.checklist.dto.response.CheckListCompletedRes;
 import com.b3.ddarelro.domain.checklist.dto.response.CheckListCreateRes;
+import com.b3.ddarelro.domain.checklist.dto.response.CheckListDeleteRes;
 import com.b3.ddarelro.domain.checklist.dto.response.CheckListGetListRes;
 import com.b3.ddarelro.domain.checklist.service.CheckListService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -44,6 +46,12 @@ public class CheckListController {
         @PathVariable Long checkListId) {
 
         CheckListCompletedRes res = checkListService.completedCheckList(checkListId);
+        return ResponseEntity.ok(res);
+    }
+
+    @DeleteMapping("/checkList/{checkListId}")
+    public ResponseEntity<CheckListDeleteRes> deleteCheckList(@PathVariable Long checkListId) {
+        CheckListDeleteRes res = checkListService.deleteCheckList(checkListId);
         return ResponseEntity.ok(res);
     }
 }

--- a/src/main/java/com/b3/ddarelro/domain/checklist/dto/request/CheckListCreateReq.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/dto/request/CheckListCreateReq.java
@@ -1,0 +1,7 @@
+package com.b3.ddarelro.domain.checklist.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CheckListCreateReq(@NotBlank(message = "내용이 공백일 수 없습니다") String content) {
+
+}

--- a/src/main/java/com/b3/ddarelro/domain/checklist/dto/response/CheckListCompletedRes.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/dto/response/CheckListCompletedRes.java
@@ -1,0 +1,8 @@
+package com.b3.ddarelro.domain.checklist.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CheckListCompletedRes(Long id, String content, Boolean completed) {
+
+}

--- a/src/main/java/com/b3/ddarelro/domain/checklist/dto/response/CheckListCreateRes.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/dto/response/CheckListCreateRes.java
@@ -1,0 +1,8 @@
+package com.b3.ddarelro.domain.checklist.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CheckListCreateRes(Long id, String content) {
+
+}

--- a/src/main/java/com/b3/ddarelro/domain/checklist/dto/response/CheckListDeleteRes.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/dto/response/CheckListDeleteRes.java
@@ -1,0 +1,8 @@
+package com.b3.ddarelro.domain.checklist.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CheckListDeleteRes(String message) {
+
+}

--- a/src/main/java/com/b3/ddarelro/domain/checklist/dto/response/CheckListGetDetailRes.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/dto/response/CheckListGetDetailRes.java
@@ -1,0 +1,8 @@
+package com.b3.ddarelro.domain.checklist.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CheckListGetDetailRes(String content, Boolean completed) {
+
+}

--- a/src/main/java/com/b3/ddarelro/domain/checklist/dto/response/CheckListGetListRes.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/dto/response/CheckListGetListRes.java
@@ -1,0 +1,19 @@
+package com.b3.ddarelro.domain.checklist.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CheckListGetListRes {
+
+    private final List<CheckListGetDetailRes> checkList;
+    private final Double donePer;
+
+    @Builder
+    public CheckListGetListRes(List<CheckListGetDetailRes> checkList) {
+        this.checkList = checkList;
+        long completedCount = checkList.stream().filter(c -> c.completed()).count();
+        this.donePer = (completedCount / (double) checkList.size()) * 100;
+    }
+}

--- a/src/main/java/com/b3/ddarelro/domain/checklist/entity/CheckList.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/entity/CheckList.java
@@ -40,4 +40,8 @@ public class CheckList extends BaseEntity {
         this.completed = false;
         this.deleted = false;
     }
+
+    public void completeToggle() {
+        this.completed = !completed;
+    }
 }

--- a/src/main/java/com/b3/ddarelro/domain/checklist/entity/CheckList.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/entity/CheckList.java
@@ -1,0 +1,43 @@
+package com.b3.ddarelro.domain.checklist.entity;
+
+import com.b3.ddarelro.domain.card.entity.Card;
+import com.b3.ddarelro.domain.common.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "tb_check_list")
+public class CheckList extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+
+    private Boolean completed;
+
+    private Boolean deleted;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Card card;
+
+    @Builder
+    public CheckList(String content, Card card) {
+        this.content = content;
+        this.card = card;
+        this.completed = false;
+        this.deleted = false;
+    }
+}

--- a/src/main/java/com/b3/ddarelro/domain/checklist/exception/CheckListErrorCode.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/exception/CheckListErrorCode.java
@@ -1,0 +1,16 @@
+package com.b3.ddarelro.domain.checklist.exception;
+
+import com.b3.ddarelro.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CheckListErrorCode implements ErrorCode {
+
+    NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 체크리스트 입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/b3/ddarelro/domain/checklist/repository/CheckListRepository.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/repository/CheckListRepository.java
@@ -1,0 +1,8 @@
+package com.b3.ddarelro.domain.checklist.repository;
+
+import com.b3.ddarelro.domain.checklist.entity.CheckList;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CheckListRepository extends JpaRepository<CheckList, Long> {
+
+}

--- a/src/main/java/com/b3/ddarelro/domain/checklist/repository/CheckListRepository.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/repository/CheckListRepository.java
@@ -3,8 +3,18 @@ package com.b3.ddarelro.domain.checklist.repository;
 import com.b3.ddarelro.domain.checklist.entity.CheckList;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CheckListRepository extends JpaRepository<CheckList, Long> {
 
     List<CheckList> findAllByCardId(Long id);
+
+    @Modifying
+    @Query(value = "update CheckList c set c.deleted = true where c.card.id in (:cardIds)")
+    void SoftDelete(List<Long> cardIds);
+
+    @Modifying
+    @Query(value = "update CheckList c set c.deleted = false where c.card.id in (:cardIds)")
+    void restoreAll(List<Long> cardIds);
 }

--- a/src/main/java/com/b3/ddarelro/domain/checklist/repository/CheckListRepository.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/repository/CheckListRepository.java
@@ -1,8 +1,10 @@
 package com.b3.ddarelro.domain.checklist.repository;
 
 import com.b3.ddarelro.domain.checklist.entity.CheckList;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CheckListRepository extends JpaRepository<CheckList, Long> {
 
+    List<CheckList> findAllByCardId(Long id);
 }

--- a/src/main/java/com/b3/ddarelro/domain/checklist/service/CheckListDeleteRestoreService.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/service/CheckListDeleteRestoreService.java
@@ -1,0 +1,24 @@
+package com.b3.ddarelro.domain.checklist.service;
+
+import com.b3.ddarelro.domain.checklist.repository.CheckListRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CheckListDeleteRestoreService {
+
+    private final CheckListRepository checkListRepository;
+
+    public void deleteAllComment(List<Long> cardIds) {
+        checkListRepository.SoftDelete(cardIds);
+    }
+
+    public void restoreAllComment(List<Long> cardIds) {
+        checkListRepository.restoreAll(cardIds);
+    }
+
+}

--- a/src/main/java/com/b3/ddarelro/domain/checklist/service/CheckListService.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/service/CheckListService.java
@@ -3,11 +3,14 @@ package com.b3.ddarelro.domain.checklist.service;
 import com.b3.ddarelro.domain.card.entity.Card;
 import com.b3.ddarelro.domain.card.service.CardService;
 import com.b3.ddarelro.domain.checklist.dto.request.CheckListCreateReq;
+import com.b3.ddarelro.domain.checklist.dto.response.CheckListCompletedRes;
 import com.b3.ddarelro.domain.checklist.dto.response.CheckListCreateRes;
 import com.b3.ddarelro.domain.checklist.dto.response.CheckListGetDetailRes;
 import com.b3.ddarelro.domain.checklist.dto.response.CheckListGetListRes;
 import com.b3.ddarelro.domain.checklist.entity.CheckList;
+import com.b3.ddarelro.domain.checklist.exception.CheckListErrorCode;
 import com.b3.ddarelro.domain.checklist.repository.CheckListRepository;
+import com.b3.ddarelro.global.exception.GlobalException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,5 +39,25 @@ public class CheckListService {
             c -> CheckListGetDetailRes.builder().content(c.getContent()).completed(c.getCompleted())
                 .build()).toList();
         return CheckListGetListRes.builder().checkList(detailRes).build();
+    }
+
+    public CheckListCompletedRes completedCheckList(Long checkListId) {
+        CheckList checkList = findCheckList(checkListId);
+        checkList.completeToggle();
+        return CheckListCompletedRes.builder().id(checkList.getId()).content(checkList.getContent())
+            .completed(checkList.getCompleted()).build();
+    }
+
+    private CheckList findCheckList(Long checkListId) {
+        CheckList checkList = checkListRepository.findById(checkListId)
+            .orElseThrow(() -> new GlobalException(CheckListErrorCode.NOT_FOUND));
+        deleteCheck(checkList);
+        return checkList;
+    }
+
+    private void deleteCheck(CheckList checkList) {
+        if (checkList.getDeleted()) {
+            throw new GlobalException(CheckListErrorCode.NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/com/b3/ddarelro/domain/checklist/service/CheckListService.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/service/CheckListService.java
@@ -4,8 +4,11 @@ import com.b3.ddarelro.domain.card.entity.Card;
 import com.b3.ddarelro.domain.card.service.CardService;
 import com.b3.ddarelro.domain.checklist.dto.request.CheckListCreateReq;
 import com.b3.ddarelro.domain.checklist.dto.response.CheckListCreateRes;
+import com.b3.ddarelro.domain.checklist.dto.response.CheckListGetDetailRes;
+import com.b3.ddarelro.domain.checklist.dto.response.CheckListGetListRes;
 import com.b3.ddarelro.domain.checklist.entity.CheckList;
 import com.b3.ddarelro.domain.checklist.repository.CheckListRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,5 +27,14 @@ public class CheckListService {
         checkListRepository.save(checkList);
         return CheckListCreateRes.builder().id(checkList.getId()).content(checkList.getContent())
             .build();
+    }
+
+    public CheckListGetListRes getCheckList(Long cardId) {
+        Card card = cardService.findCard(cardId);
+        List<CheckList> checkLists = checkListRepository.findAllByCardId(card.getId());
+        List<CheckListGetDetailRes> detailRes = checkLists.stream().map(
+            c -> CheckListGetDetailRes.builder().content(c.getContent()).completed(c.getCompleted())
+                .build()).toList();
+        return CheckListGetListRes.builder().checkList(detailRes).build();
     }
 }

--- a/src/main/java/com/b3/ddarelro/domain/checklist/service/CheckListService.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/service/CheckListService.java
@@ -5,6 +5,7 @@ import com.b3.ddarelro.domain.card.service.CardService;
 import com.b3.ddarelro.domain.checklist.dto.request.CheckListCreateReq;
 import com.b3.ddarelro.domain.checklist.dto.response.CheckListCompletedRes;
 import com.b3.ddarelro.domain.checklist.dto.response.CheckListCreateRes;
+import com.b3.ddarelro.domain.checklist.dto.response.CheckListDeleteRes;
 import com.b3.ddarelro.domain.checklist.dto.response.CheckListGetDetailRes;
 import com.b3.ddarelro.domain.checklist.dto.response.CheckListGetListRes;
 import com.b3.ddarelro.domain.checklist.entity.CheckList;
@@ -46,6 +47,12 @@ public class CheckListService {
         checkList.completeToggle();
         return CheckListCompletedRes.builder().id(checkList.getId()).content(checkList.getContent())
             .completed(checkList.getCompleted()).build();
+    }
+
+    public CheckListDeleteRes deleteCheckList(Long checkListId) {
+        CheckList checkList = findCheckList(checkListId);
+        checkListRepository.delete(checkList);
+        return CheckListDeleteRes.builder().message("체크리스트 삭제 성공").build();
     }
 
     private CheckList findCheckList(Long checkListId) {

--- a/src/main/java/com/b3/ddarelro/domain/checklist/service/CheckListService.java
+++ b/src/main/java/com/b3/ddarelro/domain/checklist/service/CheckListService.java
@@ -1,0 +1,28 @@
+package com.b3.ddarelro.domain.checklist.service;
+
+import com.b3.ddarelro.domain.card.entity.Card;
+import com.b3.ddarelro.domain.card.service.CardService;
+import com.b3.ddarelro.domain.checklist.dto.request.CheckListCreateReq;
+import com.b3.ddarelro.domain.checklist.dto.response.CheckListCreateRes;
+import com.b3.ddarelro.domain.checklist.entity.CheckList;
+import com.b3.ddarelro.domain.checklist.repository.CheckListRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class CheckListService {
+
+    private final CheckListRepository checkListRepository;
+    private final CardService cardService;
+
+    public CheckListCreateRes createCheckList(Long cardId, CheckListCreateReq req) {
+        Card card = cardService.findCard(cardId);
+        CheckList checkList = CheckList.builder().card(card).content(req.content()).build();
+        checkListRepository.save(checkList);
+        return CheckListCreateRes.builder().id(checkList.getId()).content(checkList.getContent())
+            .build();
+    }
+}


### PR DESCRIPTION
## 개요
체크리스트 API 구현, 카드에서 SoftDelete했을 때와 복구 했을 때 필요한 서비스 추가

## 작업사항
- 체크리스트 생성 구현
- 체크리스트 조회 구현
- 체크리스트 완료(토글) 구현
- 체크리스트 삭제 구현
- 카드 SoftDelete, 복구 했을 때 필요한 서비스 구현

## 변경로직
- 없음

## 관련 이슈
- close #27 
