### PR TITLE
이메일 인증 구현 및 Redis 연결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     //s3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     //Repository 테스트용
     runtimeOnly 'com.h2database:h2'
     implementation 'com.h2database:h2'

--- a/build.gradle
+++ b/build.gradle
@@ -57,11 +57,20 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 
-    //s3
+    // s3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
-    //redis
+    // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // email
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    // context
+    implementation 'org.springframework:spring-context-support'
+
+    // thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
     //Repository 테스트용
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/b3/ddarelro/domain/user/controller/EmailAuthController.java
+++ b/src/main/java/com/b3/ddarelro/domain/user/controller/EmailAuthController.java
@@ -1,0 +1,39 @@
+package com.b3.ddarelro.domain.user.controller;
+
+import com.b3.ddarelro.domain.user.dto.request.EmailAuthSendReq;
+import com.b3.ddarelro.domain.user.dto.request.EmailCodeCheckReq;
+import com.b3.ddarelro.domain.user.dto.response.EmailAuthSendRes;
+import com.b3.ddarelro.domain.user.dto.response.EmailCodeCheckRes;
+import com.b3.ddarelro.domain.user.service.EmailAuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/email")
+public class EmailAuthController {
+
+    private final EmailAuthService emailAuthService;
+
+    @PostMapping
+    public ResponseEntity<EmailAuthSendRes> sendEmail(
+        @Valid @RequestBody EmailAuthSendReq reqDto) {
+        EmailAuthSendRes resDto = emailAuthService.sendEmail(reqDto);
+        return ResponseEntity.ok(resDto);
+    }
+
+    @PatchMapping
+    public ResponseEntity<EmailCodeCheckRes> checkAuthCode(
+        @Valid @RequestBody EmailCodeCheckReq reqDto) {
+
+        EmailCodeCheckRes resDto = emailAuthService.checkAuthCode(reqDto);
+        return ResponseEntity.ok(resDto);
+    }
+
+}

--- a/src/main/java/com/b3/ddarelro/domain/user/controller/EmailController.java
+++ b/src/main/java/com/b3/ddarelro/domain/user/controller/EmailController.java
@@ -4,7 +4,7 @@ import com.b3.ddarelro.domain.user.dto.request.EmailAuthSendReq;
 import com.b3.ddarelro.domain.user.dto.request.EmailCodeCheckReq;
 import com.b3.ddarelro.domain.user.dto.response.EmailAuthSendRes;
 import com.b3.ddarelro.domain.user.dto.response.EmailCodeCheckRes;
-import com.b3.ddarelro.domain.user.service.EmailAuthService;
+import com.b3.ddarelro.domain.user.service.EmailService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,14 +17,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/email")
-public class EmailAuthController {
+public class EmailController {
 
-    private final EmailAuthService emailAuthService;
+    private final EmailService emailService;
 
     @PostMapping
     public ResponseEntity<EmailAuthSendRes> sendEmail(
         @Valid @RequestBody EmailAuthSendReq reqDto) {
-        EmailAuthSendRes resDto = emailAuthService.sendEmail(reqDto);
+        EmailAuthSendRes resDto = emailService.sendEmail(reqDto);
         return ResponseEntity.ok(resDto);
     }
 
@@ -32,7 +32,7 @@ public class EmailAuthController {
     public ResponseEntity<EmailCodeCheckRes> checkAuthCode(
         @Valid @RequestBody EmailCodeCheckReq reqDto) {
 
-        EmailCodeCheckRes resDto = emailAuthService.checkAuthCode(reqDto);
+        EmailCodeCheckRes resDto = emailService.checkAuthCode(reqDto);
         return ResponseEntity.ok(resDto);
     }
 

--- a/src/main/java/com/b3/ddarelro/domain/user/dto/request/EmailAuthSendReq.java
+++ b/src/main/java/com/b3/ddarelro/domain/user/dto/request/EmailAuthSendReq.java
@@ -1,0 +1,7 @@
+package com.b3.ddarelro.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailAuthSendReq(@NotBlank(message = "Email을 입력해주세요") String email) {
+
+}

--- a/src/main/java/com/b3/ddarelro/domain/user/dto/request/EmailCodeCheckReq.java
+++ b/src/main/java/com/b3/ddarelro/domain/user/dto/request/EmailCodeCheckReq.java
@@ -1,0 +1,12 @@
+package com.b3.ddarelro.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailCodeCheckReq(
+    @NotBlank(message = "Email을 입력해주세요")
+    String email,
+    @NotBlank(message = "인증 Code를 입력해주세요")
+    String code
+) {
+
+}

--- a/src/main/java/com/b3/ddarelro/domain/user/dto/response/EmailAuthSendRes.java
+++ b/src/main/java/com/b3/ddarelro/domain/user/dto/response/EmailAuthSendRes.java
@@ -1,0 +1,8 @@
+package com.b3.ddarelro.domain.user.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record EmailAuthSendRes(String message) {
+
+}

--- a/src/main/java/com/b3/ddarelro/domain/user/dto/response/EmailCodeCheckRes.java
+++ b/src/main/java/com/b3/ddarelro/domain/user/dto/response/EmailCodeCheckRes.java
@@ -1,0 +1,8 @@
+package com.b3.ddarelro.domain.user.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record EmailCodeCheckRes(String message) {
+
+}

--- a/src/main/java/com/b3/ddarelro/domain/user/entity/EmailAuth.java
+++ b/src/main/java/com/b3/ddarelro/domain/user/entity/EmailAuth.java
@@ -1,0 +1,24 @@
+package com.b3.ddarelro.domain.user.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RedisHash(value = "emailAuth", timeToLive = 100) // redis 사용, 유효기간 10분
+public class EmailAuth {
+
+    @Id
+    private String email;
+    private String code;
+
+    @Builder
+    private EmailAuth(String email, String code) {
+        this.email = email;
+        this.code = code;
+    }
+}

--- a/src/main/java/com/b3/ddarelro/domain/user/entity/User.java
+++ b/src/main/java/com/b3/ddarelro/domain/user/entity/User.java
@@ -3,6 +3,8 @@ package com.b3.ddarelro.domain.user.entity;
 import com.b3.ddarelro.domain.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -32,14 +34,15 @@ public class User extends BaseEntity {
     private String password;
 
     @Column(nullable = false)
-    private Boolean deleted;
+    @Enumerated(EnumType.STRING)
+    private UserStatus status;
 
     @Builder
     private User(String email, String username, String password) {
         this.email = email;
         this.username = username;
         this.password = password;
-        this.deleted = false;
+        this.status = UserStatus.PENDING;
     }
 
     public void updateUsername(String username) {
@@ -51,6 +54,10 @@ public class User extends BaseEntity {
     }
 
     public void delete() {
-        this.deleted = true;
+        this.status = UserStatus.WITHDRAWN;
+    }
+
+    public void updateStatus() {
+        this.status = UserStatus.ACTIVE;
     }
 }

--- a/src/main/java/com/b3/ddarelro/domain/user/entity/UserStatus.java
+++ b/src/main/java/com/b3/ddarelro/domain/user/entity/UserStatus.java
@@ -1,0 +1,16 @@
+package com.b3.ddarelro.domain.user.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum UserStatus {
+    PENDING("대기 중"),
+    ACTIVE("활성화"),
+    WITHDRAWN("탈퇴");
+
+    private final String status;
+
+    UserStatus(String status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/b3/ddarelro/domain/user/exception/EmailErrorCode.java
+++ b/src/main/java/com/b3/ddarelro/domain/user/exception/EmailErrorCode.java
@@ -1,0 +1,18 @@
+package com.b3.ddarelro.domain.user.exception;
+
+import com.b3.ddarelro.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum EmailErrorCode implements ErrorCode {
+
+    NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, "존재하지 않는 이메일입니다."),
+    EXPIRED_CODE(HttpStatus.BAD_REQUEST, "코드가 일치하지 않습니다");
+
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/b3/ddarelro/domain/user/exception/EmailErrorCode.java
+++ b/src/main/java/com/b3/ddarelro/domain/user/exception/EmailErrorCode.java
@@ -10,8 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum EmailErrorCode implements ErrorCode {
 
     NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, "존재하지 않는 이메일입니다."),
-    EXPIRED_CODE(HttpStatus.BAD_REQUEST, "코드가 일치하지 않습니다");
-
+    EXPIRED_CODE(HttpStatus.BAD_REQUEST, "만료된 인증코드입니다."),
+    NOT_MATCHED_CODE(HttpStatus.BAD_REQUEST, "코드가 일치하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/b3/ddarelro/domain/user/repository/EmailAuthRepository.java
+++ b/src/main/java/com/b3/ddarelro/domain/user/repository/EmailAuthRepository.java
@@ -1,0 +1,8 @@
+package com.b3.ddarelro.domain.user.repository;
+
+import com.b3.ddarelro.domain.user.entity.EmailAuth;
+import org.springframework.data.repository.CrudRepository;
+
+public interface EmailAuthRepository extends CrudRepository<EmailAuth, String> {
+
+}

--- a/src/main/java/com/b3/ddarelro/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/b3/ddarelro/domain/user/repository/UserRepository.java
@@ -3,16 +3,11 @@ package com.b3.ddarelro.domain.user.repository;
 import com.b3.ddarelro.domain.user.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
 
-    boolean existsByUsername(String username);
-
-    @Query("SELECT u FROM User u "
-        + "WHERE u.email = :email AND u.deleted = false")
-    Optional<User> findByEmailAndNotDeleted(String email);
+    Optional<User> findByEmail(String email);
 
 }

--- a/src/main/java/com/b3/ddarelro/domain/user/service/EmailAuthService.java
+++ b/src/main/java/com/b3/ddarelro/domain/user/service/EmailAuthService.java
@@ -1,44 +1,16 @@
 package com.b3.ddarelro.domain.user.service;
 
-import com.b3.ddarelro.domain.user.dto.request.EmailAuthSendReq;
-import com.b3.ddarelro.domain.user.dto.request.EmailCodeCheckReq;
-import com.b3.ddarelro.domain.user.dto.response.EmailAuthSendRes;
-import com.b3.ddarelro.domain.user.dto.response.EmailCodeCheckRes;
 import com.b3.ddarelro.domain.user.entity.EmailAuth;
-import com.b3.ddarelro.domain.user.exception.EmailErrorCode;
 import com.b3.ddarelro.domain.user.repository.EmailAuthRepository;
-import com.b3.ddarelro.global.email.EmailUtil;
-import com.b3.ddarelro.global.exception.GlobalException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class EmailAuthService {
 
     private final EmailAuthRepository emailAuthRepository;
-    private final EmailUtil emailUtil;
-    private final UserService userService;
-
-
-    @Transactional
-    public EmailAuthSendRes sendEmail(final EmailAuthSendReq reqDto) {
-        emailUtil.sendMessage(reqDto.email(), "ddarelro [이메일 인증]");
-        return EmailAuthSendRes.builder().message("인증코드가 발송되었습니다.").build();
-    }
-
-    @Transactional
-    public EmailCodeCheckRes checkAuthCode(final EmailCodeCheckReq reqDto) {
-        userService.findUserByEmail(reqDto.email());
-        if (emailUtil.checkCode(reqDto.email(), reqDto.code())) {
-            throw new GlobalException(EmailErrorCode.NOT_MATCHED_CODE);
-        }
-        return EmailCodeCheckRes.builder()
-            .message("인증이 완료되었습니다.")
-            .build();
-    }
 
     public boolean hasMail(final String email) {
         return emailAuthRepository.existsById(email);

--- a/src/main/java/com/b3/ddarelro/domain/user/service/EmailAuthService.java
+++ b/src/main/java/com/b3/ddarelro/domain/user/service/EmailAuthService.java
@@ -1,0 +1,33 @@
+package com.b3.ddarelro.domain.user.service;
+
+import com.b3.ddarelro.domain.user.entity.EmailAuth;
+import com.b3.ddarelro.domain.user.repository.EmailAuthRepository;
+import com.b3.ddarelro.global.email.EmailUtil;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailAuthService {
+
+    private final EmailAuthRepository emailAuthRepository;
+    private final EmailUtil emailUtil;
+
+
+    public boolean hasMail(final String email) {
+        return emailAuthRepository.existsById(email);
+    }
+
+    public void delete(final String email) {
+        emailAuthRepository.deleteById(email);
+    }
+
+    public EmailAuth save(final EmailAuth emailAuth) {
+        return emailAuthRepository.save(emailAuth);
+    }
+
+    public Optional<EmailAuth> findById(final String email) {
+        return emailAuthRepository.findById(email);
+    }
+}

--- a/src/main/java/com/b3/ddarelro/domain/user/service/EmailAuthService.java
+++ b/src/main/java/com/b3/ddarelro/domain/user/service/EmailAuthService.java
@@ -1,11 +1,18 @@
 package com.b3.ddarelro.domain.user.service;
 
+import com.b3.ddarelro.domain.user.dto.request.EmailAuthSendReq;
+import com.b3.ddarelro.domain.user.dto.request.EmailCodeCheckReq;
+import com.b3.ddarelro.domain.user.dto.response.EmailAuthSendRes;
+import com.b3.ddarelro.domain.user.dto.response.EmailCodeCheckRes;
 import com.b3.ddarelro.domain.user.entity.EmailAuth;
+import com.b3.ddarelro.domain.user.exception.EmailErrorCode;
 import com.b3.ddarelro.domain.user.repository.EmailAuthRepository;
 import com.b3.ddarelro.global.email.EmailUtil;
+import com.b3.ddarelro.global.exception.GlobalException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -13,7 +20,25 @@ public class EmailAuthService {
 
     private final EmailAuthRepository emailAuthRepository;
     private final EmailUtil emailUtil;
+    private final UserService userService;
 
+
+    @Transactional
+    public EmailAuthSendRes sendEmail(final EmailAuthSendReq reqDto) {
+        emailUtil.sendMessage(reqDto.email(), "ddarelro [이메일 인증]");
+        return EmailAuthSendRes.builder().message("인증코드가 발송되었습니다.").build();
+    }
+
+    @Transactional
+    public EmailCodeCheckRes checkAuthCode(final EmailCodeCheckReq reqDto) {
+        userService.findUserByEmail(reqDto.email());
+        if (emailUtil.checkCode(reqDto.email(), reqDto.code())) {
+            throw new GlobalException(EmailErrorCode.NOT_MATCHED_CODE);
+        }
+        return EmailCodeCheckRes.builder()
+            .message("인증이 완료되었습니다.")
+            .build();
+    }
 
     public boolean hasMail(final String email) {
         return emailAuthRepository.existsById(email);

--- a/src/main/java/com/b3/ddarelro/domain/user/service/EmailService.java
+++ b/src/main/java/com/b3/ddarelro/domain/user/service/EmailService.java
@@ -1,0 +1,39 @@
+package com.b3.ddarelro.domain.user.service;
+
+import com.b3.ddarelro.domain.user.dto.request.EmailAuthSendReq;
+import com.b3.ddarelro.domain.user.dto.request.EmailCodeCheckReq;
+import com.b3.ddarelro.domain.user.dto.response.EmailAuthSendRes;
+import com.b3.ddarelro.domain.user.dto.response.EmailCodeCheckRes;
+import com.b3.ddarelro.domain.user.entity.User;
+import com.b3.ddarelro.domain.user.exception.EmailErrorCode;
+import com.b3.ddarelro.global.email.EmailUtil;
+import com.b3.ddarelro.global.exception.GlobalException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final EmailUtil emailUtil;
+    private final UserService userService;
+
+    @Transactional
+    public EmailAuthSendRes sendEmail(final EmailAuthSendReq reqDto) {
+        emailUtil.sendMessage(reqDto.email(), "ddarelro [이메일 인증]");
+        return EmailAuthSendRes.builder().message("인증코드가 발송되었습니다.").build();
+    }
+
+    @Transactional
+    public EmailCodeCheckRes checkAuthCode(final EmailCodeCheckReq reqDto) {
+        User user = userService.findUserByEmail(reqDto.email());
+        if (!emailUtil.checkCode(reqDto.email(), reqDto.code())) {
+            throw new GlobalException(EmailErrorCode.NOT_MATCHED_CODE);
+        }
+        user.updateStatus();
+        return EmailCodeCheckRes.builder()
+            .message("인증이 완료되었습니다.")
+            .build();
+    }
+}

--- a/src/main/java/com/b3/ddarelro/domain/user/service/UserService.java
+++ b/src/main/java/com/b3/ddarelro/domain/user/service/UserService.java
@@ -9,6 +9,7 @@ import com.b3.ddarelro.domain.user.dto.response.UserPasswordUpdateRes;
 import com.b3.ddarelro.domain.user.dto.response.UserRes;
 import com.b3.ddarelro.domain.user.dto.response.UsernameUpdateRes;
 import com.b3.ddarelro.domain.user.entity.User;
+import com.b3.ddarelro.domain.user.entity.UserStatus;
 import com.b3.ddarelro.domain.user.exception.EmailErrorCode;
 import com.b3.ddarelro.domain.user.exception.UserErrorCode;
 import com.b3.ddarelro.domain.user.repository.UserRepository;
@@ -104,14 +105,20 @@ public class UserService {
     public User findUser(final Long id) {
         User user = userRepository.findById(id)
             .orElseThrow(() -> new GlobalException(UserErrorCode.NOT_FOUND_USER));
-        if (user.getDeleted()) {
+
+        if (user.getStatus().equals(UserStatus.PENDING)) {
+            throw new GlobalException(UserErrorCode.NOT_FOUND_USER);
+        }
+
+        if (user.getStatus().equals(UserStatus.WITHDRAWN)) {
             throw new GlobalException(UserErrorCode.DELETED_USER);
         }
+
         return user;
     }
 
     public User findUserByEmail(final String email) {
-        return userRepository.findByEmailAndNotDeleted(email)
+        return userRepository.findByEmail(email)
             .orElseThrow(() -> new GlobalException(EmailErrorCode.NOT_FOUND_EMAIL));
     }
 

--- a/src/main/java/com/b3/ddarelro/domain/user/service/UserService.java
+++ b/src/main/java/com/b3/ddarelro/domain/user/service/UserService.java
@@ -9,6 +9,7 @@ import com.b3.ddarelro.domain.user.dto.response.UserPasswordUpdateRes;
 import com.b3.ddarelro.domain.user.dto.response.UserRes;
 import com.b3.ddarelro.domain.user.dto.response.UsernameUpdateRes;
 import com.b3.ddarelro.domain.user.entity.User;
+import com.b3.ddarelro.domain.user.exception.EmailErrorCode;
 import com.b3.ddarelro.domain.user.exception.UserErrorCode;
 import com.b3.ddarelro.domain.user.repository.UserRepository;
 import com.b3.ddarelro.domain.userboard.repository.UserBoardRepository;
@@ -26,6 +27,7 @@ public class UserService {
     private final UserBoardRepository userBoardRepository;
     private final PasswordEncoder passwordEncoder;
 
+    // TODO: 탈퇴한 회원이 다시 회원가입할 때 처리
     public void signup(final UserSignupReq reqDto) {
 
         if (userRepository.existsByEmail(reqDto.email())) {
@@ -106,6 +108,11 @@ public class UserService {
             throw new GlobalException(UserErrorCode.DELETED_USER);
         }
         return user;
+    }
+
+    public User findUserByEmail(final String email) {
+        return userRepository.findByEmailAndNotDeleted(email)
+            .orElseThrow(() -> new GlobalException(EmailErrorCode.NOT_FOUND_EMAIL));
     }
 
     private void validateDeleteUser(User user) {

--- a/src/main/java/com/b3/ddarelro/global/config/EmailConfig.java
+++ b/src/main/java/com/b3/ddarelro/global/config/EmailConfig.java
@@ -1,0 +1,68 @@
+package com.b3.ddarelro.global.config;
+
+import java.util.Properties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class EmailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connection-timeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.write-timeout}")
+    private int writeTimeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.connection-timeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.write-timeout", writeTimeout);
+
+        return properties;
+    }
+}

--- a/src/main/java/com/b3/ddarelro/global/config/EmailConfig.java
+++ b/src/main/java/com/b3/ddarelro/global/config/EmailConfig.java
@@ -22,22 +22,19 @@ public class EmailConfig {
     @Value("${spring.mail.password}")
     private String password;
 
-    @Value("${spring.mail.properties.mail.smtp.auth}")
+    @Value("${spring.mail.properties.smtp.auth}")
     private boolean auth;
 
-    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    @Value("${spring.mail.properties.smtp.starttls.enable}")
     private boolean starttlsEnable;
 
-    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
-    private boolean starttlsRequired;
-
-    @Value("${spring.mail.properties.mail.smtp.connection-timeout}")
+    @Value("${spring.mail.properties.smtp.connection-timeout}")
     private int connectionTimeout;
 
-    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    @Value("${spring.mail.properties.smtp.timeout}")
     private int timeout;
 
-    @Value("${spring.mail.properties.mail.smtp.write-timeout}")
+    @Value("${spring.mail.properties.smtp.write-timeout}")
     private int writeTimeout;
 
     @Bean

--- a/src/main/java/com/b3/ddarelro/global/config/RedisConfig.java
+++ b/src/main/java/com/b3/ddarelro/global/config/RedisConfig.java
@@ -1,0 +1,24 @@
+package com.b3.ddarelro.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@EnableRedisRepositories
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+}

--- a/src/main/java/com/b3/ddarelro/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/b3/ddarelro/global/config/WebSecurityConfig.java
@@ -65,6 +65,7 @@ public class WebSecurityConfig {
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
                 .permitAll()
                 .requestMatchers("/api/users/signup/**").permitAll()
+                .requestMatchers("/api/email/**").permitAll()
                 .anyRequest().authenticated()
         );
         http.addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);

--- a/src/main/java/com/b3/ddarelro/global/email/EmailUtil.java
+++ b/src/main/java/com/b3/ddarelro/global/email/EmailUtil.java
@@ -53,15 +53,12 @@ public class EmailUtil {
     }
 
     public boolean checkCode(String to, String code) {
-        try {
-            EmailAuth emailAuth = emailAuthService.findById(to)
-                .orElseThrow(() -> new GlobalException(
-                    EmailErrorCode.NOT_FOUND_EMAIL));
 
-            return emailAuth.getCode().equals(code);
-        } catch (Exception e) {
-            throw new GlobalException(EmailErrorCode.EXPIRED_CODE);
-        }
+        EmailAuth emailAuth = emailAuthService.findById(to)
+            .orElseThrow(() -> new GlobalException(
+                EmailErrorCode.EXPIRED_CODE));
+
+        return emailAuth.getCode().equals(code);
     }
 
     private MimeMessage createMessage(String to, String subject, String code)

--- a/src/main/java/com/b3/ddarelro/global/email/EmailUtil.java
+++ b/src/main/java/com/b3/ddarelro/global/email/EmailUtil.java
@@ -1,0 +1,85 @@
+package com.b3.ddarelro.global.email;
+
+import com.b3.ddarelro.domain.user.entity.EmailAuth;
+import com.b3.ddarelro.domain.user.exception.EmailErrorCode;
+import com.b3.ddarelro.domain.user.service.EmailAuthService;
+import com.b3.ddarelro.global.exception.GlobalException;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMessage.RecipientType;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+@Slf4j(topic = "email 인증코드 생성 및 발송")
+@Component
+@RequiredArgsConstructor
+public class EmailUtil {
+
+    private final JavaMailSender mailSender;
+    private final SpringTemplateEngine templateEngine;
+    private final EmailAuthService emailAuthService;
+
+    @Value("${spring.mail.username}")
+    private String email;
+
+    public String createAuthCode() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    public void sendMessage(String to, String subject) {
+        try {
+            String code = createAuthCode();
+            MimeMessage message = createMessage(to, subject, code);
+
+            if (emailAuthService.hasMail(to)) {
+                emailAuthService.delete(to);
+            }
+            EmailAuth emailAuth = EmailAuth.builder()
+                .email(to)
+                .code(code)
+                .build();
+
+            emailAuthService.save(emailAuth);
+            mailSender.send(message);
+        } catch (MessagingException e) {
+            log.warn(e.getMessage());
+        }
+    }
+
+    public boolean checkCode(String to, String code) {
+        try {
+            EmailAuth emailAuth = emailAuthService.findById(to)
+                .orElseThrow(() -> new GlobalException(
+                    EmailErrorCode.NOT_FOUND_EMAIL));
+
+            return emailAuth.getCode().equals(code);
+        } catch (Exception e) {
+            throw new GlobalException(EmailErrorCode.EXPIRED_CODE);
+        }
+    }
+
+    private MimeMessage createMessage(String to, String subject, String code)
+        throws MessagingException {
+        MimeMessage message = mailSender.createMimeMessage();
+
+        message.setFrom(email);
+        message.addRecipients(RecipientType.TO, to);
+        message.setSubject(subject);
+        message.setText(createMailHtml(code), "UTF-8", "html");
+
+        return message;
+    }
+
+    private String createMailHtml(String code) {
+        Context context = new Context();
+        context.setVariable("code", code);
+        return templateEngine.process("email", context);
+    }
+
+}

--- a/src/main/java/com/b3/ddarelro/global/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/b3/ddarelro/global/security/JwtAuthorizationFilter.java
@@ -12,6 +12,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -52,6 +53,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
                 setAuthentication(info.getSubject());
             } catch (Exception e) {
                 log.error("Authentication error: {}", e.getMessage());
+                sendErrorResponse(response, HttpStatus.SC_BAD_REQUEST, "만료된 토큰입니다.");
                 return;
             }
         }

--- a/src/main/java/com/b3/ddarelro/global/security/UserDetailsImpl.java
+++ b/src/main/java/com/b3/ddarelro/global/security/UserDetailsImpl.java
@@ -2,6 +2,7 @@ package com.b3.ddarelro.global.security;
 
 
 import com.b3.ddarelro.domain.user.entity.User;
+import com.b3.ddarelro.domain.user.entity.UserStatus;
 import java.util.Collection;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -50,6 +51,6 @@ public class UserDetailsImpl implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return !user.getDeleted();
+        return user.getStatus().equals(UserStatus.ACTIVE);
     }
 }

--- a/src/main/java/com/b3/ddarelro/global/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/b3/ddarelro/global/security/UserDetailsServiceImpl.java
@@ -1,6 +1,7 @@
 package com.b3.ddarelro.global.security;
 
 import com.b3.ddarelro.domain.user.entity.User;
+import com.b3.ddarelro.domain.user.entity.UserStatus;
 import com.b3.ddarelro.domain.user.exception.UserErrorCode;
 import com.b3.ddarelro.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,9 +18,12 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        User user = userRepository.findByEmailAndNotDeleted(email)
+        User user = userRepository.findByEmail(email)
             .orElseThrow(
                 () -> new IllegalArgumentException(UserErrorCode.NOT_FOUND_USER.getMessage()));
+        if (!user.getStatus().equals(UserStatus.ACTIVE)) {
+            throw new IllegalArgumentException(UserErrorCode.NOT_FOUND_USER.getMessage());
+        }
         return new UserDetailsImpl(user);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,14 +17,20 @@ spring:
         format_sql: true
       dialect: org.hibernate.dialect.MySQL8InnoDBDialect
     defer-datasource-initialization: true
-    sql:
-      init:
-        mode: always
-        encoding: UTF-8
 
-  jwt:
-    secret:
-      key: ${JWT_SECRET_KEY}
+  sql:
+    init:
+      mode: always
+      encoding: UTF-8
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+jwt:
+  secret:
+    key: ${JWT_SECRET_KEY}
 
 cloud:
   aws:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,21 @@ spring:
       host: localhost
       port: 6379
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      smtp:
+        auth: true
+        starttls:
+          enable: true
+        connection-timeout: 5000 #클라이언트가 SMTP서버와 연결을 설정하는데 대기해야하는 시간(ms)
+        timeout: 5000 #클라이언트가 SMTP서버로부터 응답을 대기해야하는 시간(ms)
+        write-timeout: 5000 #클라이언트가 작업을 완료하는데 대기해야 하는 시간(ms)
+
+
 jwt:
   secret:
     key: ${JWT_SECRET_KEY}

--- a/src/main/resources/templates/email.html
+++ b/src/main/resources/templates/email.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="ko"
+      xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>Ddarelro 이메일 인증 코드입니다.</title>
+</head>
+<body style="width: 100%; margin: 0 auto; padding: 10px;">
+<div align="center">
+  <h1 class="text-center">
+    Ddarelro
+  </h1>
+</div>
+<div align="center">
+  <div align='center' style='border:1px solid black; width: 300px'>
+    <h3 style='color:blue;'>인증 코드입니다.</h3>
+    <div style='font-size:130%'>
+      CODE : <strong th:text="${code}"></strong>
+      <br/>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/src/test/java/com/b3/ddarelro/domain/board/BoardIntegrationTest.java
+++ b/src/test/java/com/b3/ddarelro/domain/board/BoardIntegrationTest.java
@@ -74,6 +74,7 @@ public class BoardIntegrationTest {
             .password("123456789")
             .email("123@naver.com")
             .build();
+        user1.updateStatus();
         user = userRepository.save(user1);
 
         User user2 = User.builder()
@@ -81,7 +82,7 @@ public class BoardIntegrationTest {
             .email("test1@test.com")
             .password("12345678")
             .build();
-
+        user2.updateStatus();
         otherUser = userRepository.save(user2);
 
         User user3 = User.builder()
@@ -89,7 +90,7 @@ public class BoardIntegrationTest {
             .email("test2@test.com")
             .password("123456789")
             .build();
-
+        user3.updateStatus();
         otherUser2 = userRepository.save(user3);
 
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -17,7 +17,7 @@ spring:
   data:
     redis:
       host: localhost
-      port: 6370
+      port: 6379
 
   mail:
     host: test.test.test
@@ -29,6 +29,9 @@ spring:
         auth: true
         starttls:
           enable: true
+        connection-timeout: 5000 #클라이언트가 SMTP서버와 연결을 설정하는데 대기해야하는 시간(ms)
+        timeout: 5000 #클라이언트가 SMTP서버로부터 응답을 대기해야하는 시간(ms)
+        write-timeout: 5000 #클라이언트가 작업을 완료하는데 대기해야 하는 시간(ms)
 
 jwt:
   secret:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -19,6 +19,17 @@ spring:
       host: localhost
       port: 6370
 
+  mail:
+    host: test.test.test
+    port: 1234
+    username: test@test.test
+    password: test test test test
+    properties:
+      smtp:
+        auth: true
+        starttls:
+          enable: true
+
 jwt:
   secret:
     key: testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest


### PR DESCRIPTION
## 개요
gmail SMTP 이메일 인증 구현, Redis 연결

## 작업사항
- 이메일 인증코드 발송 API 구현
- 이메일 인증코드 확인 API 구현
- 회원 가입 및 회원탈퇴, 로그인시 로직 수정

## 변경로직
- User deleted 필드 -> status 필드로 수정(UserStatus Enum 사용 : ACTIVE(활성화), PENDING(가입대기), WITHDRAWN(탈퇴))
- 회원가입 직후 status PENDING으로 설정. >> 이메일 인증코드 확인후 ACTIVE 설정
- 이메일 인증코드(유효시간 10분) 레디스 DB로 저장

## 관련 이슈
- close #44 
- 실행시(yml) redis 연결, 메일 연결 작업 해야함